### PR TITLE
Change actor to child, Gnome 46 support

### DIFF
--- a/order-extensions@wa4557.github.com/extension.js
+++ b/order-extensions@wa4557.github.com/extension.js
@@ -77,7 +77,7 @@ function _addToPanelBox(role, indicator, position, box) {
     container.show();
     const parent = container.get_parent();
     if (parent) {
-        parent.remove_actor(container);
+        parent.remove_child(container);
     }
 
     this.statusArea[role] = indicator;


### PR DESCRIPTION
Very trivia change. Changed remove_actor to  remove_child. Thanks for this extension!