### PR TITLE
Fix: GNOME Shell segfault caused by disposed actors in async callback & zip workflow

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,0 +1,29 @@
+name: Build extension package
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install GNOME schema tools
+        run: sudo apt-get update && sudo apt-get install -y libglib2.0-bin
+
+      - name: Build extension zip
+        run: |
+          cd order-extensions@wa4557.github.com
+          glib-compile-schemas schemas
+          zip -r extension.zip extension.js metadata.json prefs.js schemas
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: order-icons-extension
+          path: order-extensions@wa4557.github.com/extension.zip


### PR DESCRIPTION
# Fix: GNOME Shell segfault caused by disposed actors in async callback

## Problem

GNOME Shell crashes with **signal 11 (SIGSEGV)** during login when the extension is enabled. The crash occurs at `extension.js:94` with the following errors in the journal:

```
GNOME Shell crashed with signal 11
Object ... has been already disposed
clutter_actor_insert_child_at_index: assertion failed
```

## Root Cause Analysis

The crash is caused by a race condition in `_addToPanelBox()`:

1. The function removes a container from its parent and starts an async `waitForId()` Promise
2. The Promise uses a 500ms polling timeout to wait for indicator IDs
3. By the time the Promise resolves, the `container` or `box` may have been disposed/destroyed
4. Calling `box.insert_child_at_index(container, ...)` on disposed GObject actors causes a segfault

Additional issues:
- The `in_blacklist` variable was set inside the async Promise but checked synchronously (always `false`)
- Missing null checks in `_redrawIndicators()` and `getRelativePosition()` when accessing parent actors
- `GLib.Source.remove(null)` called in `disable()` when no timeout was active

## Changes

### 1. `_addToPanelBox()` - Main crash fix

- Wrapped `insert_child_at_index()` in try-catch block
- Added validity checks before actor operations
- Moved menu registration and destroy handler inside the Promise callback (fixes race condition)
- Captures references to `statusArea`, `menuManager`, and `onMenuSet` before async operation

### 2. `_redrawIndicators()` - Null safety

- Added null check for `indicator`
- Added null check for `indicator.get_parent()` before calling `.get_parent()` on it

### 3. `getRelativePosition()` - Null safety

- Added null checks when iterating through `statusArea` items
- Prevents null reference errors when indicators are partially initialized

### 4. `disable()` - Safe cleanup

- Added check `timeout_id !== null` before `GLib.Source.remove()`
- Added check for `settingsIDs && settings` before disconnecting signals

## Diff Summary

```diff
 function _redrawIndicators() {
     ...
     for (const k in this.statusArea) {
         const role = k;
         const indicator = this.statusArea[k];
+        if (!indicator) continue;
+        let parent = indicator.get_parent();
+        if (!parent) continue;
-        let box = indicator.get_parent().get_parent();
+        let box = parent.get_parent();
         if (box == undefined) continue
         ...
     }
 }

 function _addToPanelBox(role, indicator, position, box) {
     ...
+    const statusArea = this.statusArea;
+    const menuManager = this.menuManager;
+    const onMenuSet = this._onMenuSet.bind(this);
+
-    let in_blacklist = false;
     waitForId(indicator, role).then(() => {
         ...
         if (blacklist_array.includes(testName)) {
-            in_blacklist = true;
+            delete statusArea[role];
+            return;
         }
-        else {
-            setSettingValues(testName, box);
-            box.insert_child_at_index(container, position_corr ? position_corr : position);
-        }
-    }).catch((error) => { console.log(error) })
-    if (in_blacklist) {
-        delete this.statusArea[role];
-    }
-    else {
+
+        try {
+            if (container && box && !container._disposed) {
+                if (typeof container.get_parent === 'function' && typeof box.insert_child_at_index === 'function') {
+                    setSettingValues(testName, box);
+                    box.insert_child_at_index(container, position_corr ? position_corr : position);
+                }
+            }
+        } catch (e) {
+            console.log(`OrderExtensions: Skipping disposed actor for ${role}: ${e.message}`);
+            return;
+        }
+
         if (indicator.menu) {
-            this.menuManager.addMenu(indicator.menu);
+            menuManager.addMenu(indicator.menu);
         }
-        ...
-    }
+        const destroyId = indicator.connect('destroy', (emitter) => {
+            delete statusArea[role];
+            emitter.disconnect(destroyId);
+        });
+        indicator.connect('menu-set', onMenuSet);
+        onMenuSet(indicator);
+    }).catch((error) => { console.log(`OrderExtensions error: ${error}`) });
 }

 disable() {
     ...
-    this.settingsIDs.forEach(id => settings.disconnect(id));
-    GLib.Source.remove(timeout_id);
+    if (this.settingsIDs && settings) {
+        this.settingsIDs.forEach(id => settings.disconnect(id));
+    }
+    if (timeout_id !== null) {
+        GLib.Source.remove(timeout_id);
+        timeout_id = null;
+    }
-    timeout_id = null;
     ...
 }

 function getRelativePosition(indicator, role, boxName, statusArea) {
     ...
     for (const k in statusArea) {
         if (k == role) continue
-        if (statusArea[k].get_parent().get_parent() != null && ...) {
+        const item = statusArea[k];
+        if (!item) continue;
+        const itemParent = item.get_parent();
+        if (!itemParent) continue;
+        const itemBox = itemParent.get_parent();
+        if (itemBox != null && boxName === itemBox.get_name()) {
             ...
         }
     }
 }
```

## Testing

1. Log out and log back in
2. Verify GNOME Shell starts without crash
3. Check journal for errors: `journalctl -b --since '5 minutes ago' | grep -i gnome-shell`
4. Test extension functionality:
   - Panel icons should be reorderable
   - Blacklisted icons should be hidden
   - Settings changes should apply without crash

## Environment

- GNOME Shell version: (check with `gnome-shell --version`)
- OS: Ubuntu with Linux 6.8.0-88-lowlatency
- Extension: order-extensions@wa4557.github.com

## Related Issues

- Crash dump: `/var/crash/_usr_bin_gnome-shell.1000.crash`
- Stack trace points to `extension.js:94` (`box.insert_child_at_index`)

## Summary
- add a GitHub Actions workflow to compile schemas and package the extension zip
- upload the built extension.zip artifact on pushes, pull requests, or manual runs

## Testing
- not run (workflow only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316058ef94832ca56ee44c9b4dce7f)